### PR TITLE
Ensure a pre binary with a leading zero is treated as invalid

### DIFF
--- a/test/prop_verl.erl
+++ b/test/prop_verl.erl
@@ -19,8 +19,10 @@ prop_basic_valid_semver0() ->
             V =
                 <<Major/binary, <<".">>/binary, Minor/binary, <<".">>/binary, Patch/binary,
                     <<"-">>/binary, Pre/binary>>,
-            case re:run(Pre, "^[0-9A-Za-z-]+$") of
-                nomatch ->
+            case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0")} of
+                {nomatch, _} -> 
+                    {error, invalid_version} =:= verl:parse(V);
+                {_, {match, _}}   ->
                     {error, invalid_version} =:= verl:parse(V);
                 _ ->
                     {ok, Parsed} = verl:parse(V),

--- a/test/prop_verl.erl
+++ b/test/prop_verl.erl
@@ -20,7 +20,7 @@ prop_basic_valid_semver0() ->
                 <<Major/binary, <<".">>/binary, Minor/binary, <<".">>/binary, Patch/binary,
                     <<"-">>/binary, Pre/binary>>,
             case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0")} of
-                {nomatch, _} -> 
+                {nomatch, _} ->
                     {error, invalid_version} =:= verl:parse(V);
                 {_, {match, _}}   ->
                     {error, invalid_version} =:= verl:parse(V);


### PR DESCRIPTION
A pre element in a version binary with a leading zero is invalid and should be treated as such. We were previously not checking for this resulting in intermittent failures in our property tests.