### PR TITLE
Pre element may be a single zero

### DIFF
--- a/test/prop_verl.erl
+++ b/test/prop_verl.erl
@@ -19,7 +19,7 @@ prop_basic_valid_semver0() ->
             V =
                 <<Major/binary, <<".">>/binary, Minor/binary, <<".">>/binary, Patch/binary,
                     <<"-">>/binary, Pre/binary>>,
-            case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0")} of
+            case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0.+")} of
                 {nomatch, _} ->
                     {error, invalid_version} =:= verl:parse(V);
                 {_, {match, _}}   ->


### PR DESCRIPTION
A pre element may have a single zero and must be treated as a valid semver case.