### PR TITLE
crlf in pre must be treated as in invalid case

### DIFF
--- a/test/prop_verl.erl
+++ b/test/prop_verl.erl
@@ -19,7 +19,7 @@ prop_basic_valid_semver0() ->
             V =
                 <<Major/binary, <<".">>/binary, Minor/binary, <<".">>/binary, Patch/binary,
                     <<"-">>/binary, Pre/binary>>,
-            case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0.+")} of
+            case {re:run(Pre, "^[0-9A-Za-z-]+$"), re:run(Pre, "^0.+|[\r\n]")} of
                 {nomatch, _} ->
                     {error, invalid_version} =:= verl:parse(V);
                 {_, {match, _}}   ->


### PR DESCRIPTION
If pre contains a crlf it must be treated as an invalid case.