### PR TITLE
Add common helper functions

### DIFF
--- a/src/verl.erl
+++ b/src/verl.erl
@@ -1,5 +1,6 @@
 -module(verl).
 
+%% Main API
 -export([
     compare/2,
     is_match/2,
@@ -7,6 +8,16 @@
     parse/1,
     parse_requirement/1,
     compile_requirement/1
+]).
+
+%% Helpers
+-export([
+    between/3,
+    eq/2,
+    gt/2,
+    gte/2,
+    lt/2,
+    lte/2
 ]).
 
 -type version() :: binary().
@@ -51,6 +62,8 @@
     requirement_t/0,
     compiled_requirement/0
 ]).
+
+%%% Primary API
 
 %%% @doc
 %%% Compares two versions, returning whether the first argument is greater, equal, or
@@ -147,6 +160,90 @@ to_matchable(String, AllowPre) when is_binary(String) ->
             {Major, Minor, Patch, Pre, AllowPre};
         {error, invalid_version} ->
             {error, invalid_version}
+    end.
+
+%%% Helper functions
+
+%%% @doc
+%%% Helper function that returns true if the first version is greater than the third version and
+%%% also the second version is less than the the third version, otherwise returns false.
+%%% See `compare/2' for more details.
+%%% @end
+-spec between(version(), version(), version()) -> boolean() | {error, invalid_version}.
+between(Vsn1, Vsn2, VsnMatch) ->
+    case {gte(VsnMatch, Vsn1), lte(VsnMatch, Vsn2)} of
+        {true, true} ->
+            true;
+        {{error, _} = Err, _} ->
+            Err;
+        {_, {error, _} = Err} ->
+            Err;
+        _ ->
+            false
+    end.
+
+%%% @doc
+%%% Helper function that returns true if two versions are equal, otherwise false. See `compare/2' for
+%%% more details.
+%%% @end
+-spec eq(version(), version()) -> boolean() | {error, invalid_version}.
+eq(Vsn1, Vsn2) ->
+    case compare(Vsn1, Vsn2) of
+        eq -> true;
+        {error, _} = Err -> Err;
+        _ -> false
+    end.
+
+%%% @doc
+%%% Helper function that returns true the first version given is greater than the second, otherwise returns false.
+%%% See `compare/2' for more details.
+%%% @end
+-spec gt(version(), version()) -> boolean() | {error, invalid_version}.
+gt(Vsn1, Vsn2) ->
+    case compare(Vsn1, Vsn2) of
+        gt -> true;
+        {error, _} = Err -> Err;
+        _ -> false
+    end.
+
+%%% @doc
+%%% Helper function that returns true the first version given is greater than or equal to the second,
+%%% otherwise returns false.
+%%% See `compare/2' for more details.
+%%% @end
+-spec gte(version(), version()) -> boolean() | {error, invalid_version}.
+gte(Vsn1, Vsn2) ->
+    case compare(Vsn1, Vsn2) of
+        gt -> true;
+        eq -> true;
+        {error, _} = Err -> Err;
+        _ -> false
+    end.
+
+%%% @doc
+%%% Helper function that returns true the first version given is less than the second, otherwise returns false.
+%%% See `compare/2' for more details.
+%%% @end
+-spec lt(version(), version()) -> boolean() | {error, invalid_version}.
+lt(Vsn1, Vsn2) ->
+    case compare(Vsn1, Vsn2) of
+        lt -> true;
+        {error, _} = Err -> Err;
+        _ -> false
+    end.
+
+%%% @doc
+%%% Helper function that returns true the first version given is less than or equal to the second,
+%%% otherwise returns false.
+%%% See `compare/2' for more details.
+%%% @end
+-spec lte(version(), version()) -> boolean() | {error, invalid_version}.
+lte(Vsn1, Vsn2) ->
+    case compare(Vsn1, Vsn2) of
+        lt -> true;
+        eq -> true;
+        {error, _} = Err -> Err;
+        _ -> false
     end.
 
 %% private

--- a/src/verl.erl
+++ b/src/verl.erl
@@ -183,8 +183,8 @@ between(Vsn1, Vsn2, VsnMatch) ->
     end.
 
 %%% @doc
-%%% Helper function that returns true if two versions are equal, otherwise false. See `compare/2' for
-%%% more details.
+%%% Helper function that returns true if two versions are equal, otherwise
+%%% false. See `compare/2' for more details.
 %%% @end
 -spec eq(version(), version()) -> boolean() | {error, invalid_version}.
 eq(Vsn1, Vsn2) ->
@@ -195,8 +195,8 @@ eq(Vsn1, Vsn2) ->
     end.
 
 %%% @doc
-%%% Helper function that returns true the first version given is greater than the second, otherwise returns false.
-%%% See `compare/2' for more details.
+%%% Helper function that returns true the first version given is greater than
+%%% the second, otherwise returns false. See `compare/2' for more details.
 %%% @end
 -spec gt(version(), version()) -> boolean() | {error, invalid_version}.
 gt(Vsn1, Vsn2) ->
@@ -207,8 +207,8 @@ gt(Vsn1, Vsn2) ->
     end.
 
 %%% @doc
-%%% Helper function that returns true the first version given is greater than or equal to the second,
-%%% otherwise returns false.
+%%% Helper function that returns true the first version given is greater than
+%%% or equal to the second, otherwise returns false.
 %%% See `compare/2' for more details.
 %%% @end
 -spec gte(version(), version()) -> boolean() | {error, invalid_version}.
@@ -221,8 +221,8 @@ gte(Vsn1, Vsn2) ->
     end.
 
 %%% @doc
-%%% Helper function that returns true the first version given is less than the second, otherwise returns false.
-%%% See `compare/2' for more details.
+%%% Helper function that returns true the first version given is less than the
+%%% second, otherwise returns false. See `compare/2' for more details.
 %%% @end
 -spec lt(version(), version()) -> boolean() | {error, invalid_version}.
 lt(Vsn1, Vsn2) ->
@@ -233,8 +233,8 @@ lt(Vsn1, Vsn2) ->
     end.
 
 %%% @doc
-%%% Helper function that returns true the first version given is less than or equal to the second,
-%%% otherwise returns false.
+%%% Helper function that returns true the first version given is less than or
+%%% equal to the second, otherwise returns false.
 %%% See `compare/2' for more details.
 %%% @end
 -spec lte(version(), version()) -> boolean() | {error, invalid_version}.

--- a/src/verl_parser.erl
+++ b/src/verl_parser.erl
@@ -5,13 +5,13 @@
 -type operator() :: '!=' | '&&' | '<' | '<=' | '==' | '>' | '>=' | '||' | '~>' | bitstring().
 
 -spec parse_version(verl:version()) ->
-    {ok, {verl:major(), verl:minor(), verl:patch(), [verl:pre()], [verl:build()]}} |
-    {error, invalid_version}.
+    {ok, {verl:major(), verl:minor(), verl:patch(), [verl:pre()], [verl:build()]}}
+    | {error, invalid_version}.
 parse_version(Str) -> parse_version(Str, false).
 
 -spec parse_version(verl:version(), boolean()) ->
-    {ok, {verl:major(), verl:minor(), verl:patch(), [verl:pre()], [verl:build()]}} |
-    {error, invalid_version}.
+    {ok, {verl:major(), verl:minor(), verl:patch(), [verl:pre()], [verl:build()]}}
+    | {error, invalid_version}.
 parse_version(Str, Approximate) when is_binary(Str) ->
     try parse_and_convert(Str, Approximate) of
         {ok, {_, _, undefined, _, _}} ->
@@ -287,16 +287,19 @@ maybe_patch(Patch, _) ->
     to_digits(Patch).
 
 -spec parse_and_convert(verl:version(), boolean()) ->
-    {error, invalid_version} |
-    {ok,
-        {integer(), integer(),
-            'undefined' |
+    {error, invalid_version}
+    | {ok,
+        {
             integer(),
+            integer(),
+            'undefined'
+            | integer(),
             [
-                binary() |
-                integer()
+                binary()
+                | integer()
             ],
-            [binary()]}}.
+            [binary()]
+        }}.
 parse_and_convert(Str, Approx) ->
     [VerPre, Build] = bisect(Str, <<"+">>, [global]),
     [Ver, Pre] = bisect(VerPre, <<"-">>, []),

--- a/test/prop_verl.erl
+++ b/test/prop_verl.erl
@@ -7,7 +7,8 @@
 %%% Properties %%%
 %%%%%%%%%%%%%%%%%%
 
--dialyzer({no_opaque, prop_basic_valid_semver0/0}). % test for equality with opaque term
+% test for equality with opaque term
+-dialyzer({no_opaque, prop_basic_valid_semver0/0}).
 prop_basic_valid_semver0() ->
     ?FORALL(
         {Maj, Min, P, Pre},
@@ -22,7 +23,7 @@ prop_basic_valid_semver0() ->
             case {re:run(Pre, "^[0-9A-Za-z-+]+$"), re:run(Pre, "(^0[0-9]+)|(^[+]$)|[\r\n]")} of
                 {nomatch, _} ->
                     {error, invalid_version} =:= verl:parse(V);
-                {_, {match, _}}   ->
+                {_, {match, _}} ->
                     {error, invalid_version} =:= verl:parse(V);
                 _ ->
                     {ok, Parsed} = verl:parse(V),
@@ -45,7 +46,8 @@ prop_basic_valid_semver0() ->
         end
     ).
 
--dialyzer({no_opaque, prop_basic_valid_semver/0}). % test for equality with opaque term
+% test for equality with opaque term
+-dialyzer({no_opaque, prop_basic_valid_semver/0}).
 prop_basic_valid_semver() ->
     ?FORALL(
         {Maj, Min, P},

--- a/test/verl_SUITE.erl
+++ b/test/verl_SUITE.erl
@@ -3,9 +3,145 @@
 -compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 all() ->
-    [compare_test, parse_test, parse_requirement_test, compile_requirement_test, is_match_test].
+    [
+        between_test,
+        compare_test,
+        eq_test,
+        gt_test,
+        gte_test,
+        lt_test,
+        lte_test,
+        parse_test,
+        parse_requirement_test,
+        compile_requirement_test,
+        is_match_test
+    ].
+
+between_test(_Config) ->
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha.3">>,
+            <<"1.0.0-alpha.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-alpha.25">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-beta.7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-pre-alpha.2">>,
+            <<"1.0.0-pre-alpha.11">>,
+            <<"1.0.0-pre-alpha.7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-rc.3">>,
+            <<"1.0.0-rc.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-rc.1">>,
+            <<"1.0.0-rc.1+build.3">>,
+            <<"1.0.0-rc.1+build.1">>
+        )
+    ),
+
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-rc.1+build.1">>,
+            <<"1.0.0">>,
+            <<"1.0.0-rc.33">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0">>,
+            <<"1.0.0+0.3.7">>,
+            <<"1.0.0+0.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.3.7+build">>,
+            <<"1.3.7+build.2.b8f12d7">>,
+            <<"1.3.7+build.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.3.7+build.2.b8f12d7">>,
+            <<"1.3.7+build.11.e0f985a">>,
+            <<"1.3.7+build.10.a36faa">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:between(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:between(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-alpha.22">>,
+            <<"1.0.0">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:between(
+            <<"1.0.0-pre-alpha.1">>,
+            <<"1.0.0-pre-alpha.22">>,
+            <<"1.0.0">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:between(
+            <<"1.0.0-beta.1">>,
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:between(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-rc.1">>,
+            <<"1.0.0-rc.22">>
+        )
+    ).
 
 compare_test(_Cfg) ->
     gt = verl:compare(<<"1.0.1">>, <<"1.0.0">>),
@@ -33,7 +169,133 @@ compare_test(_Cfg) ->
     {error, invalid_version} = verl:compare(<<"1.0.0-dev">>, <<"1.0">>),
     {error, invalid_version} = verl:compare(<<"foo">>, <<"1.0.0-a">>).
 
--dialyzer({[no_opaque, no_return], parse_test/1}). % match against opaque
+eq_test(_Config) ->
+    ?assertMatch(true, verl:eq(<<"1.0.0-a">>, <<"1.0.0-a">>)),
+    ?assertMatch(true, verl:eq(<<"1.0.0-alpha">>, <<"1.0.0-alpha">>)),
+    ?assertMatch(true, verl:eq(<<"1.0.0-dev">>, <<"1.0.0-dev">>)),
+    ?assertMatch(true, not verl:eq(<<"1.0.0">>, <<"1.0.1">>)),
+    ?assertMatch(true, not verl:eq(<<"1.0.0-alpha">>, <<"1.0.1+alpha">>)),
+    ?assertMatch(true, not verl:eq(<<"1.0.0+build.1">>, <<"1.0.1+build.2">>)).
+
+gt_test(_Config) ->
+    ?assertMatch(
+        true,
+        verl:gt(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:gt(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:gt(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:gt(
+            <<"1.0.0-pre-alpha.14">>,
+            <<"1.0.0-pre-alpha.3">>
+        )
+    ),
+    ?assertMatch(true, verl:gt(<<"1.0.0-rc.1">>, <<"1.0.0-beta.11">>)),
+    ?assertMatch(true, verl:gt(<<"1.0.0">>, <<"1.0.0-rc.1+build.1">>)),
+    ?assertMatch(true, verl:gt(<<"1.3.7+build">>, <<"1.0.0+0.3.7">>)),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-beta.11">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-rc.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-pre-alpha.3">>,
+            <<"1.0.0-pre-alpha.14">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-rc.1">>,
+            <<"1.0.0-rc.1+build.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-rc.1+build.1">>,
+            <<"1.0.0">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0">>,
+            <<"1.0.0+0.3.7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0+0.3.7">>,
+            <<"1.3.7+build">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.3.7+build">>,
+            <<"1.3.7+build.2.b8f12d7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.3.7+build.2.b8f12d7">>,
+            <<"1.3.7+build.11.e0f985a">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:gt(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha">>
+        )
+    ).
+
+% match against opaque
+-dialyzer({[no_opaque, no_return], parse_test/1}).
 parse_test(_Cfg) ->
     Exp0 = #{major => 1, minor => 2, patch => 3, pre => [], build => undefined},
     {ok, Exp0} = verl:parse(<<"1.2.3">>),
@@ -65,12 +327,16 @@ parse_test(_Cfg) ->
     ExpErr = verl:parse(<<"2.03.0">>),
     ExpErr = verl:parse(<<"02.3.0">>).
 
--dialyzer({[no_opaque, no_return], parse_requirement_test/1}). % match against opaque
+% match against opaque
+-dialyzer({[no_opaque, no_return], parse_requirement_test/1}).
 parse_requirement_test(_Cfg) ->
     Str = <<"1.2.3">>,
     ExpSpec = [
-        {{'$1', '$2', '$3', '$4', '$5'},
-            [{'==', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}], ['$_']}
+        {
+            {'$1', '$2', '$3', '$4', '$5'},
+            [{'==', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}],
+            ['$_']
+        }
     ],
     {ok, #{string := Str, matchspec := ExpSpec, compiled := false}} =
         verl:parse_requirement(Str),
@@ -81,7 +347,8 @@ parse_requirement_test(_Cfg) ->
     ExpErr = verl:parse_requirement(<<"_ 1.2.3">>),
     ExpErr = verl:parse_requirement(<<"( ) 1.2.3">>).
 
--dialyzer({[no_opaque, no_return], compile_requirement_test/1}). % match against opaque
+% match against opaque
+-dialyzer({[no_opaque, no_return], compile_requirement_test/1}).
 compile_requirement_test(_Cfg) ->
     {ok, Req} = verl:parse_requirement(<<"1.2.3">>),
     #{compiled := true, matchspec := Ref} = verl:compile_requirement(Req),
@@ -94,7 +361,8 @@ compile_requirement_test(_Cfg) ->
             true = is_reference(Ref)
     end.
 
--dialyzer({[no_opaque, no_return], is_match_test/1}). % opaque as arg
+% opaque as arg
+-dialyzer({[no_opaque, no_return], is_match_test/1}).
 is_match_test(_Cfg) ->
     {error, invalid_version} = verl:is_match(<<"foo">>, <<"2.3.0">>),
     {error, invalid_requirement} = verl:is_match(<<"2.3.0">>, <<"foo">>),
@@ -183,3 +451,244 @@ is_match_test(_Cfg) ->
     false = verl:is_match(<<"2.2.0-dev">>, <<"~> 2.1.0">>, [{allow_pre, false}]),
     false = verl:is_match(<<"2.2.0-dev">>, <<"~> 2.1.0-dev">>),
     false = verl:is_match(<<"2.2.0-dev">>, <<"~> 2.1.0-dev">>, [{allow_pre, false}]).
+
+gte_test(_Config) ->
+    ?assertMatch(true, verl:gte(<<"1.0.0-alpha">>, <<"1.0.0-alpha">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0-pre-alpha.2">>, <<"1.0.0-pre-alpha">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0-beta.2">>, <<"1.0.0-alpha.1">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0-rc.1">>, <<"1.0.0-beta.11">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0-rc.1+build.1">>, <<"1.0.0-rc.1">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0">>, <<"1.0.0-rc.1+build.1">>)),
+    ?assertMatch(true, verl:gte(<<"1.0.0+0.3.7">>, <<"1.0.0">>)),
+    ?assertMatch(true, verl:gte(<<"1.3.7+build">>, <<"1.0.0+0.3.7">>)),
+    ?assertMatch(true, verl:gte(<<"1.3.7+build.2.b8f12d7">>, <<"1.3.7+build">>)),
+    ?assertMatch(true, verl:gte(<<"1.3.7+build.11.e0f985a">>, <<"1.3.7+build.2.b8f12d7">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-alpha">>, <<"1.0.0-alpha.1">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-pre-alpha">>, <<"1.0.0-pre-alpha.1">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-alpha.1">>, <<"1.0.0-beta.2">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-beta.2">>, <<"1.0.0-beta.11">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-beta.11">>, <<"1.0.0-rc.1">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0-rc.1+build.1">>, <<"1.0.0">>)),
+    ?assertMatch(true, not verl:gte(<<"1.0.0+0.3.7">>, <<"1.3.7+build">>)).
+
+lt_test(_Config) ->
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-beta.11">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-pre-alpha.3">>,
+            <<"1.0.0-pre-alpha.14">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-rc.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0-rc.1+build.1">>,
+            <<"1.0.0">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lt(
+            <<"1.0.0+0.3.7">>,
+            <<"1.3.7+build">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.0.0-pre-alpha.14">>,
+            <<"1.0.0-pre-alpha.3">>
+        )
+    ),
+    ?assertMatch(true, not verl:lt(<<"1.0.0-rc.1">>, <<"1.0.0-beta.11">>)),
+    ?assertMatch(true, not verl:lt(<<"1.0.0-rc.1+build.1">>, <<"1.0.0-rc.1">>)),
+    ?assertMatch(true, not verl:lt(<<"1.0.0">>, <<"1.0.0-rc.1+build.1">>)),
+    ?assertMatch(true, not verl:lt(<<"1.0.0+0.3.7">>, <<"1.0.0">>)),
+    ?assertMatch(true, not verl:lt(<<"1.3.7+build">>, <<"1.0.0+0.3.7">>)),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.3.7+build.2.b8f12d7">>,
+            <<"1.3.7+build">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lt(
+            <<"1.3.7+build.11.e0f985a">>,
+            <<"1.3.7+build.2.b8f12d7">>
+        )
+    ).
+
+lte_test(_Config) ->
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-beta.11">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-pre-alpha.2">>,
+            <<"1.0.0-pre-alpha.11">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-rc.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-rc.1">>,
+            <<"1.0.0-rc.1+build.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-rc.1+build.1">>,
+            <<"1.0.0">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0">>,
+            <<"1.0.0+0.3.7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0+0.3.7">>,
+            <<"1.3.7+build">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.3.7+build">>,
+            <<"1.3.7+build.2.b8f12d7">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.3.7+build.2.b8f12d7">>,
+            <<"1.3.7+build.11.e0f985a">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        verl:lte(
+            <<"1.0.0-alpha">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lte(
+            <<"1.0.0-alpha.1">>,
+            <<"1.0.0-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lte(
+            <<"1.0.0-pre-alpha.2">>,
+            <<"1.0.0-pre-alpha">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lte(
+            <<"1.0.0-beta.2">>,
+            <<"1.0.0-alpha.1">>
+        )
+    ),
+    ?assertMatch(
+        true,
+        not verl:lte(
+            <<"1.0.0-beta.11">>,
+            <<"1.0.0-beta.2">>
+        )
+    ),
+    ?assertMatch(true, not verl:lte(<<"1.0.0-rc.1">>, <<"1.0.0-beta.11">>)),
+    ?assertMatch(true, not verl:lte(<<"1.0.0">>, <<"1.0.0-rc.1+build.1">>)),
+    ?assertMatch(true, not verl:lte(<<"1.3.7+build">>, <<"1.0.0+0.3.7">>)).

--- a/test/verl_parser_SUITE.erl
+++ b/test/verl_parser_SUITE.erl
@@ -7,7 +7,8 @@
 all() ->
     [parse_version_test, parse_requirement_test].
 
--dialyzer({[no_opaque, no_return], parse_version_test/1}). % match against opaque
+% match against opaque
+-dialyzer({[no_opaque, no_return], parse_version_test/1}).
 parse_version_test(_Cfg) ->
     {ok, {1, 2, 3, [], []}} = verl_parser:parse_version(<<"1.2.3">>),
     {ok, {1, 4, 5, [], [<<"ignore">>]}} = verl_parser:parse_version(<<"1.4.5+ignore">>),
@@ -42,13 +43,19 @@ parse_version_test(_Cfg) ->
 
 parse_requirement_test(_Cfg) ->
     ExpSpec0 = [
-        {{'$1', '$2', '$3', '$4', '$5'},
-            [{'==', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}], ['$_']}
+        {
+            {'$1', '$2', '$3', '$4', '$5'},
+            [{'==', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}],
+            ['$_']
+        }
     ],
     {ok, ExpSpec0} = verl_parser:parse_requirement(<<"1.2.3">>),
     ExpSpec1 = [
-        {{'$1', '$2', '$3', '$4', '$5'},
-            [{'/=', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}], ['$_']}
+        {
+            {'$1', '$2', '$3', '$4', '$5'},
+            [{'/=', {{'$1', '$2', '$3', '$4'}}, {const, {1, 2, 3, []}}}],
+            ['$_']
+        }
     ],
     {ok, ExpSpec1} = verl_parser:parse_requirement(<<"!= 1.2.3">>),
     {ok, _} = verl_parser:parse_requirement(<<"~> 1.2.3">>),


### PR DESCRIPTION
 - adds eq/2, lt/2, gt/2, lte/2, gte/2, and between/3
 - format test code

Test cases are copy / pasta from erlware_commons. Not all tests could be copied over a good bit of them either were not semver2 or the assertion in ec_semver was not correct per semver2 spec. 